### PR TITLE
Update this repository to Inactive Development Status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.eggs
+*.egg-info
+build
+dist
+venv
+*.pyc
+.cache
+.tox

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         ],
     },
     install_requires=[
-        'pytest>=2.0',
+        'pytest>=2,<4',
         'pyflakes>=0.4',
         'pep8',
     ],

--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,11 @@ setup(
         'pep8',
     ],
     setup_requires=['hgdistver'],
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Framework :: Pytest',
+        'Development Status :: 7 - Inactive',
+    ],
 )

--- a/tests/test_pep8.py
+++ b/tests/test_pep8.py
@@ -1,4 +1,8 @@
-def pytest_funcarg__testdir(request):
+import pytest
+
+
+@pytest.fixture
+def testdir(request):
     testdir = request.getfuncargvalue('testdir')
     testdir.makeini('[pytest]\ncodechecks = pep8')
     return testdir

--- a/tests/test_pyflakes.py
+++ b/tests/test_pyflakes.py
@@ -1,4 +1,8 @@
-def pytest_funcarg__testdir(request):
+import pytest
+
+
+@pytest.fixture
+def testdir(request):
     testdir = request.getfuncargvalue('testdir')
     testdir.makeini('[pytest]\ncodechecks = pyflakes')
     return testdir
@@ -25,5 +29,5 @@ def test_reportinfo_verbose(testdir):
         ''')
     out = testdir.runpytest('-v')
     out.stdout.fnmatch_lines([
-        '*test_reportinfo_verbose.py:0: codecheck pyflakes PASSED',
+        'test_reportinfo_verbose.py::pyflakes PASSED*'
     ])

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,13 @@
 [pytest]
 codechecks = pep8 pyflakes
+
 [tox]
-envlist= py26,py27,py32
-indexserver =
-    default = http://pypi.testrun.org
-    pypi = http://pypi.python.org/simple
+envlist = py{37,38}-pytest{2,3}
 
 [testenv]
-deps=
-    pytest
-    :pypi:pyflakes
-    :pypi:pep8
+deps = 
+    pytest2: pytest>2,<3
+    pytest3: pytest>3,<4
+
 commands =
-    py.test \
-        --junitxml={envlogdir}/junit-{envname}.xml \
-        []
+    py.test tests


### PR DESCRIPTION
I did some maintenance on this repo. This include

- [X] Add a basic .gitignore file
- [X] Update and test package dependencies
- [X] Fix test failures and made it compatible with pytest>3 and fixed a warning
- [X] Update package classifiers to identify the pytest plugin and show the devlopment status (inactive)

I would greatly appreciate if the updated classifiers could be published to PyPI! Since the last release was in February of 2010 and according to [pypistats.org](https://pypistats.org/packages/pytest-codecheckers) one could alternatively even remove the package from PyPI.